### PR TITLE
Allow aws sdk for all of 2.x

### DIFF
--- a/fastlane-plugin-aws_sns.gemspec
+++ b/fastlane-plugin-aws_sns.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'aws-sdk', '~> 2.0.0'
+  spec.add_dependency 'aws-sdk', '~> 2.0'
 
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'bundler'

--- a/lib/fastlane/plugin/aws_sns/version.rb
+++ b/lib/fastlane/plugin/aws_sns/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module AwsSns
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end


### PR DESCRIPTION
Fixes #1 